### PR TITLE
bugfix: allow child actions to be rendered

### DIFF
--- a/build/build.cake
+++ b/build/build.cake
@@ -35,7 +35,7 @@ Task("Version")
 		CreateDirectory(dest);
 	}
 
-	version = "0.0.1";
+	version = "0.0.2";
 
 	PatchAssemblyInfo("../src/Opten.Umbraco.ListViewPreviewLayout/Properties/AssemblyInfo.cs", version);
 

--- a/src/Opten.Umbraco.ListViewPreviewLayout/Controllers/ContentRenderController.cs
+++ b/src/Opten.Umbraco.ListViewPreviewLayout/Controllers/ContentRenderController.cs
@@ -27,6 +27,7 @@ namespace Opten.Umbraco.ListViewPreviewLayout.Controllers
 			var renderModel = new RenderModel(typedModel, System.Threading.Thread.CurrentThread.CurrentUICulture);
 
 			RouteData.DataTokens["umbraco"] = renderModel;
+			RouteData.DataTokens["area"] = "";
 			ViewData.Model = renderModel;
 
 			if (templateId > 0)


### PR DESCRIPTION
problem was, that the area was set in the ContentRenderController. because of that the childaction rout could not be found. Solution is to set the area to an empty string